### PR TITLE
Small improvement - Ignore empty fields.

### DIFF
--- a/src/Telegram.Bot.Extensions.LoginWidget/LoginWidget.cs
+++ b/src/Telegram.Bot.Extensions.LoginWidget/LoginWidget.cs
@@ -62,10 +62,13 @@ namespace Telegram.Bot.Extensions.LoginWidget
             StringBuilder dataStringBuilder = new StringBuilder(256);
             foreach (var field in fields)
             {
-                dataStringBuilder.Append(field.Key);
-                dataStringBuilder.Append('=');
-                dataStringBuilder.Append(field.Value);
-                dataStringBuilder.Append('\n');
+                if (!string.IsNullOrEmpty(field.Value))
+                {
+                    dataStringBuilder.Append(field.Key);
+                    dataStringBuilder.Append('=');
+                    dataStringBuilder.Append(field.Value);
+                    dataStringBuilder.Append('\n');
+                }
             }
             dataStringBuilder.Length -= 1; // Remove the last \n
 


### PR DESCRIPTION
Some of data can be empty, for example, "username", or "lastname", in this case if we pass this key with empty value - we will get an error "wrong hash".